### PR TITLE
Support full-path workflow through less aggressive HISTIGNORE

### DIFF
--- a/.exports
+++ b/.exports
@@ -13,5 +13,10 @@ export HISTCONTROL=ignoredups
 HISTTIMEFORMAT='%F %T '
 export HISTTIMEFORMAT
 
-# Make some commands not show up in history
-export HISTIGNORE="ls:ls *:cd:cd -:pwd;exit:date:* --help"
+# Make some commands not show up in history, while supporting
+# the full-path-plus-history workflow:
+#
+#   ls /var/log/foo/log.gz.^I^I20161004.gz
+#   zless !$
+#
+export HISTIGNORE="ls:cd:cd -:pwd;exit:date:* --help"


### PR DESCRIPTION
The current HISTIGNORE is dangerous, because it can cause well defined work patterns like the one below to fail catastrophically when the ls command is unexpectedly omitted from the history.

In the example session below, `^I` indicates that tab completion is being used.  The `ls !$` means "remove the last argument of previous command" but really removes /etc/passwd without these changes.

```
less /etc/passwd
ls /var/cache/bi^I^Igfile.junk
rm !$
```

By removing ls with arguments from the ignored commands, this full-path workflow can be supported.